### PR TITLE
Fix table sorting for string columns

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -336,7 +336,7 @@ function Table({ onInfoClick, activeCategory }) {
         return [...filtered].sort((a, b) => {
             const valA = a[sortKey];
             const valB = b[sortKey];
-            if (sortKey === "region") {
+            if (typeof valA === "string") {
                 return sortAsc ? valA.localeCompare(valB) : valB.localeCompare(valA);
             }
             return sortAsc ? valA - valB : valB - valA;


### PR DESCRIPTION
## Summary
- fix wrong table sorting when clicking Name or Region headers

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686803e5ec88832c9a559bd2ec51facf